### PR TITLE
kubernetes resource names cannot be longer than 24 characters.

### DIFF
--- a/cassandra.jinja
+++ b/cassandra.jinja
@@ -4,7 +4,7 @@
 {% set RC_COLLECTION = COLLECTION_PREFIX + 'replicationcontrollers' %}
 {% set SERVICE_COLLECTION = COLLECTION_PREFIX + 'services' %}
 
-{% set NAME_PREFIX = env['deployment'] + '-' + env['name'] %}
+{% set NAME_PREFIX = env['deployment'] %}
 {% set OPSCENTER_NAME = NAME_PREFIX + '-opscenter' %}
 {% set NODE_NAME = NAME_PREFIX + '-node' %}
 {% set SEED_NAME = NAME_PREFIX + '-seed' %}


### PR DESCRIPTION
Instead of prefixing with deployment and template name, just use
deployment. May still be too long but less likely.